### PR TITLE
Fix createTouchEvent to create bubbling events if the original event had 

### DIFF
--- a/lib/thumbs.js
+++ b/lib/thumbs.js
@@ -58,7 +58,7 @@
 
         event.initMouseEvent(
             name,
-            e.cancelBubble,
+            e.bubbles,
             e.cancelable,
             e.view,
             e.detail,


### PR DESCRIPTION
Up until now all events thumbs.js created for me did not bubble, which disabled all js functionality based on event delegation.
